### PR TITLE
Clarify Sora prompt guidance about duration handling

### DIFF
--- a/sora_cli.py
+++ b/sora_cli.py
@@ -62,7 +62,8 @@ PROMPT_GUIDANCE = textwrap.dedent(
     - Camera perspective, motion, framing, and transitions.
     - Lighting, color palette, and mood.
     - Style (photorealistic, cinematic, animation) and post-processing notes.
-    - Desired duration, aspect ratio, and output format hints.
+    - Aspect ratio and output format hints.
+    - Do not mention duration; it is configured separately via the API parameters.
     """
 ).strip()
 


### PR DESCRIPTION
## Summary
- update the prompt guidance so it no longer asks for durations and instead clarifies they are controlled via API parameters

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4872977ac832fa307b5571203b4be