### PR TITLE
Update CI workflow to Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to use Python 3.13 when running pytest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e489c446e4832f813c27afdc6dadc0