### PR TITLE
Add README guidance for running tests with uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,17 @@ Requirements:
 Run without `--dry-run` to submit a job, then wait for the video to download into the current directory. Use `--help` for advanced options (duration, output size, auto-approval, etc.).
 Add `--skip-refinement` to send your prompt directly to Sora without the GPT-5 refinement pass.
 Add `--refine-only` to run the refinement step (with GPT-5) and print the improved prompt without generating video.
+
+## Running Tests
+
+Use `uv` to run the test suite with `pytest` (dependencies are resolved automatically):
+
+```bash
+uv run --with pytest pytest
+```
+
+To execute a single test module, append its path:
+
+```bash
+uv run --with pytest pytest tests/test_image_cli.py
+```


### PR DESCRIPTION
## Summary
- add instructions to the README for running the test suite with uv and pytest
- document how to target an individual test module when using uv

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e48a9c6748832fa864e4d06a8b80c9