### PR TITLE
Allow selecting Sora model

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For landscape/portrait orientation, include it in your prompt (e.g., "landscape 
 
 Use `--help` for more options:
 - `--file` - Read prompt from a file
-- `--model` - Override model (defaults to gpt-5-mini)
+- `--model` - Override model (defaults to gpt-image-1)
 - `--dry-run` - Preview without generating
 
 ## Sora CLI
@@ -40,6 +40,7 @@ Requirements:
 Run without `--dry-run` to submit a job, then wait for the video to download into the current directory. Use `--help` for advanced options (duration, output size, auto-approval, etc.).
 Add `--skip-refinement` to send your prompt directly to Sora without the GPT-5 refinement pass.
 Add `--refine-only` to run the refinement step (with GPT-5) and print the improved prompt without generating video.
+Use `--model` to choose between `sora-2` (default) and `sora-2-pro` when creating the video job.
 
 ## Running Tests
 

--- a/sora_cli.py
+++ b/sora_cli.py
@@ -42,6 +42,7 @@ except ImportError as exc:  # pragma: no cover - runtime failure path
 DEFAULT_DURATION = 8
 DEFAULT_SIZE = "1280x720"
 DEFAULT_SORA_MODEL = "sora-2"
+ALLOWED_SORA_MODELS = ("sora-2", "sora-2-pro")
 DEFAULT_REASONING_MODEL = "gpt-5"
 
 ALLOWED_VIDEO_SIZES = {
@@ -135,9 +136,12 @@ def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
         help="Print the request payload instead of calling Sora.",
     )
     parser.add_argument(
+        "--model",
         "--sora-model",
+        dest="sora_model",
+        choices=sorted(ALLOWED_SORA_MODELS),
         default=DEFAULT_SORA_MODEL,
-        help="Override Sora model identifier.",
+        help="Sora model identifier to use.",
     )
     parser.add_argument(
         "--refinement-model",

--- a/tests/test_sora_cli.py
+++ b/tests/test_sora_cli.py
@@ -132,12 +132,17 @@ def test_build_video_request_payload_defaults():
 
 
 def test_build_video_request_payload_custom():
-    args = make_args(duration=12, size="1792x1024", sora_model="sora-x")
+    args = make_args(duration=12, size="1792x1024", sora_model="sora-2-pro")
     payload = sora_cli.build_video_request_payload("Prompt", args)
 
-    assert payload["model"] == "sora-x"
+    assert payload["model"] == "sora-2-pro"
     assert payload["seconds"] == "12"
     assert payload["size"] == "1792x1024"
+
+
+def test_parse_args_invalid_model():
+    with pytest.raises(SystemExit):
+        sora_cli.parse_args(["--model", "not-supported", "--prompt", "hi"])
 
 
 def test_normalize_duration_invalid(capsys):


### PR DESCRIPTION
## Summary
- add CLI support for selecting the sora video model via --model/--sora-model
- validate allowed video models and document the sora-2/sora-2-pro options

## Testing
- uv run --with pytest pytest

------
https://chatgpt.com/codex/tasks/task_e_68e53a1bd938832fa14dd65adc8f6bbe