### PR TITLE
Add coverage comment action to CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,13 @@ jobs:
         with:
           python-version: '3.13'
       - name: Install dependencies
-        run: pip install pytest
-      - name: Run tests
-        run: pytest
+        run: pip install coverage pytest
+      - name: Run tests with coverage
+        run: coverage run -m pytest
+      - name: Generate coverage report
+        run: coverage xml
+      - name: Python Coverage Comment
+        uses: py-cov-action/python-coverage-comment-action@v3.38
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          coverage-file: coverage.xml


### PR DESCRIPTION
## Summary
- install coverage alongside pytest in the CI workflow
- run the test suite through coverage and produce an XML report
- add the python-coverage-comment action to publish coverage results

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6718bec98832f962f092d1beb5ce0